### PR TITLE
fix(plugins): resolve Core plugin loading in standalone builds

### DIFF
--- a/src/Core/NupkgExtractor.cs
+++ b/src/Core/NupkgExtractor.cs
@@ -57,7 +57,7 @@ public sealed class NupkgExtractor(ILogger<NupkgExtractor> logger)
         }
 
         var fileCount = 0;
-        using var archive = await Task.Run(() => ZipFile.OpenRead(nupkgPath), cancellationToken);
+        using var archive = await ZipFile.OpenReadAsync(nupkgPath, cancellationToken);
 
         // All files go into plugins/{PackageId}/ subfolder
         // This keeps main DLL and dependencies together for clean isolation
@@ -75,8 +75,14 @@ public sealed class NupkgExtractor(ILogger<NupkgExtractor> logger)
             var fileName = Path.GetFileName(item);
             var destPath = Path.Combine(pluginDir, fileName);
 
-            await using var entryStream = await Task.Run(() => entry.Open(), cancellationToken);
-            await using var fileStream = File.Create(destPath);
+            await using var entryStream = await entry.OpenAsync(cancellationToken);
+            await using var fileStream = new FileStream(
+                destPath,
+                FileMode.Create,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 65536,
+                useAsync: true);
             await entryStream.CopyToAsync(fileStream, cancellationToken);
 
             logger.ExtractedFile(fileName, pluginDir);

--- a/src/Core/PluginContext.cs
+++ b/src/Core/PluginContext.cs
@@ -22,8 +22,25 @@ internal sealed class PluginContext(IReadOnlyList<LoadedPluginInfo> plugins, ILo
                     RegisterCommand(rootCommand, pluginInfo.Plugin, descriptor, onCommandRegistered);
                 }
             }
+            catch (InvalidOperationException ex)
+            {
+                // DI resolution failure (missing service registration) or command creation error
+                Console.Error.WriteLine(
+                    $"Error: Plugin '{pluginInfo.Plugin.Metadata.Name}' failed to register commands: {ex.Message}");
+                logger.CommandRegistrationFailed(pluginInfo.Plugin.Metadata.Name, ex);
+            }
+            catch (ArgumentException ex)
+            {
+                // Invalid command configuration (duplicate names, invalid options)
+                Console.Error.WriteLine(
+                    $"Error: Plugin '{pluginInfo.Plugin.Metadata.Name}' has invalid command configuration: {ex.Message}");
+                logger.CommandRegistrationFailed(pluginInfo.Plugin.Metadata.Name, ex);
+            }
             catch (Exception ex)
             {
+                // Safety net: ensure a single broken plugin cannot crash CLI construction
+                Console.Error.WriteLine(
+                    $"Error: Plugin '{pluginInfo.Plugin.Metadata.Name}' failed unexpectedly: {ex.Message}");
                 logger.CommandRegistrationFailed(pluginInfo.Plugin.Metadata.Name, ex);
             }
         }

--- a/src/Core/PluginLoadContext.cs
+++ b/src/Core/PluginLoadContext.cs
@@ -18,31 +18,43 @@ namespace Spectara.Revela.Core;
 /// Shared assemblies (IPlugin interface, Microsoft.Extensions.*) are resolved
 /// from the default context to enable cross-context communication.
 /// </remarks>
-internal sealed class PluginLoadContext(string pluginPath)
-    : AssemblyLoadContext(name: Path.GetFileNameWithoutExtension(pluginPath), isCollectible: false)
+internal sealed class PluginLoadContext : AssemblyLoadContext
 {
-    private readonly AssemblyDependencyResolver resolver = new(pluginPath);
+    private readonly AssemblyDependencyResolver resolver;
 
     /// <summary>
     /// Plugin directory contains main DLL and all dependencies.
     /// </summary>
-    private readonly string pluginDirectory = Path.GetDirectoryName(pluginPath)!;
+    private readonly string pluginDirectory;
+
+    public PluginLoadContext(string pluginPath)
+        : base(name: Path.GetFileNameWithoutExtension(pluginPath), isCollectible: false)
+    {
+        resolver = new AssemblyDependencyResolver(pluginPath);
+        pluginDirectory = Path.GetDirectoryName(pluginPath)!;
+    }
 
     /// <summary>
-    /// Known shared assemblies that should be loaded from the host.
+    /// Known shared assemblies that should be loaded from the host (exact match).
     /// </summary>
     /// <remarks>
+    /// <para>
     /// These assemblies define contracts between host and plugins.
-    /// Loading them from the plugin would break type compatibility.
-    /// Note: Spectara.Revela.* and Microsoft.Extensions.* are handled by convention in IsSharedAssembly().
+    /// Loading them from the plugin directory would break type compatibility.
+    /// </para>
+    /// <para>
+    /// Additional shared assemblies are detected by naming convention in <see cref="IsSharedAssembly"/>:
+    /// <c>Spectara.Revela.*</c>, <c>Microsoft.Extensions.*</c>, <c>Spectre.Console.*</c>.
+    /// </para>
+    /// <para>
+    /// <b>SYNC:</b> These rules must match the exclusion filters in
+    /// <c>src/Sdk/build/Spectara.Revela.Sdk.targets</c> (target <c>_RevelaIncludePluginDependencies</c>).
+    /// </para>
     /// </remarks>
     private static readonly HashSet<string> SharedAssemblies =
     [
         // System.CommandLine for CLI integration
-        "System.CommandLine",
-
-        // Spectre.Console for consistent UI
-        "Spectre.Console"
+        "System.CommandLine"
     ];
 
     protected override Assembly? Load(AssemblyName assemblyName)
@@ -57,25 +69,7 @@ internal sealed class PluginLoadContext(string pluginPath)
         // This ensures IPlugin from plugin == IPlugin from host
         if (IsSharedAssembly(name))
         {
-            // First, check if already loaded in any context
-            var alreadyLoaded = AppDomain.CurrentDomain.GetAssemblies()
-                .FirstOrDefault(a => string.Equals(a.GetName().Name, name, StringComparison.Ordinal));
-
-            if (alreadyLoaded != null)
-            {
-                return alreadyLoaded;
-            }
-
-            // For single-file publish, try to load from default context
-            try
-            {
-                return Default.LoadFromAssemblyName(assemblyName);
-            }
-            catch
-            {
-                // If not found, return null to let the framework try
-                return null;
-            }
+            return LoadFromHost(assemblyName, name);
         }
 
         // Try resolver first (for NuGet-style layouts)
@@ -96,6 +90,32 @@ internal sealed class PluginLoadContext(string pluginPath)
         return null;
     }
 
+    /// <summary>
+    /// Loads an assembly from the host (default context or already-loaded assemblies).
+    /// </summary>
+    private static Assembly? LoadFromHost(AssemblyName assemblyName, string name)
+    {
+        // First, check if already loaded in any context
+        var alreadyLoaded = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => string.Equals(a.GetName().Name, name, StringComparison.Ordinal));
+
+        if (alreadyLoaded is not null)
+        {
+            return alreadyLoaded;
+        }
+
+        // For single-file publish, try to load from default context
+        try
+        {
+            return Default.LoadFromAssemblyName(assemblyName);
+        }
+        catch
+        {
+            // If not found, return null to let the framework try
+            return null;
+        }
+    }
+
     protected override nint LoadUnmanagedDll(string unmanagedDllName)
     {
         var libraryPath = resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
@@ -114,6 +134,12 @@ internal sealed class PluginLoadContext(string pluginPath)
     {
         // Exact match for third-party shared assemblies
         if (SharedAssemblies.Contains(assemblyName))
+        {
+            return true;
+        }
+
+        // Spectre.Console.* are always shared (UI contract)
+        if (assemblyName.StartsWith("Spectre.Console", StringComparison.Ordinal))
         {
             return true;
         }

--- a/src/Core/PluginLoader.cs
+++ b/src/Core/PluginLoader.cs
@@ -140,15 +140,14 @@ public sealed partial class PluginLoader(
             }
             catch (ReflectionTypeLoadException rtle)
             {
-                // Log detailed info for debugging
-                if (logger.IsEnabled(LogLevel.Debug))
-                {
-                    LogPluginReflectionLoadFailed(fileName, rtle.Message);
-                }
+                // Write to stderr directly — bootstrap phase has no console logger
+                Console.Error.WriteLine(
+                    $"Error: Plugin '{fileName}' failed to load: {rtle.Message}");
                 foreach (var ex in rtle.LoaderExceptions.Where(e => e != null).Take(3))
                 {
                     if (ex is FileNotFoundException fnf && !string.IsNullOrEmpty(fnf.FileName))
                     {
+                        Console.Error.WriteLine($"  Missing dependency: {fnf.FileName}");
                         LogMissingDependency(fnf.FileName);
                     }
                 }
@@ -157,6 +156,9 @@ public sealed partial class PluginLoader(
             }
             catch (Exception ex)
             {
+                // Write to stderr directly — bootstrap phase has no console logger
+                Console.Error.WriteLine(
+                    $"Error: Plugin '{fileName}' failed to load: {ex.Message}");
                 LogPluginLoadFailed(ex, dll);
             }
         }

--- a/src/Core/PluginManager.cs
+++ b/src/Core/PluginManager.cs
@@ -66,14 +66,24 @@ public sealed class PluginManager(
                 logger.InstallingFromFile(packageIdOrPath);
                 return await InstallFromNupkgAsync(packageIdOrPath, targetDir, Path.GetFullPath(packageIdOrPath), cancellationToken);
             }
-            else if (Uri.TryCreate(packageIdOrPath, UriKind.Absolute, out var uri) &&
-                     (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+            else if (Uri.TryCreate(packageIdOrPath, UriKind.Absolute, out var uri))
             {
-                // URL to .nupkg
-                logger.InstallingFromUrl(packageIdOrPath);
-                return await InstallFromUrlAsync(uri, targetDir, cancellationToken);
+                if (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
+                {
+                    // URL to .nupkg
+                    logger.InstallingFromUrl(packageIdOrPath);
+                    return await InstallFromUrlAsync(uri, targetDir, cancellationToken);
+                }
+                else if (uri.Scheme == Uri.UriSchemeFile)
+                {
+                    // file:///path/to/plugin.nupkg → treat as local path
+                    var filePath = uri.LocalPath;
+                    logger.InstallingFromFile(filePath);
+                    return await InstallFromNupkgAsync(filePath, targetDir, filePath, cancellationToken);
+                }
             }
-            else
+
+            // Fall through: treat as NuGet package ID
             {
                 // Package ID from NuGet feed
                 logger.InstallingPlugin(packageIdOrPath);

--- a/src/Plugins/Calendar/CalendarPlugin.cs
+++ b/src/Plugins/Calendar/CalendarPlugin.cs
@@ -17,7 +17,7 @@ namespace Spectara.Revela.Plugins.Calendar;
 public sealed class CalendarPlugin : IPlugin
 {
     /// <inheritdoc />
-    public PluginMetadata Metadata => new()
+    public PluginMetadata Metadata { get; } = new()
     {
         Id = "Spectara.Revela.Plugins.Calendar",
         Name = "Calendar",

--- a/src/Plugins/Compress/CompressPlugin.cs
+++ b/src/Plugins/Compress/CompressPlugin.cs
@@ -22,7 +22,7 @@ namespace Spectara.Revela.Plugins.Compress;
 public sealed class CompressPlugin : IPlugin
 {
     /// <inheritdoc />
-    public PluginMetadata Metadata => new()
+    public PluginMetadata Metadata { get; } = new()
     {
         Id = "Spectara.Revela.Plugins.Compress",
         Name = "Static Compression",

--- a/src/Plugins/Core/Directory.Build.props
+++ b/src/Plugins/Core/Directory.Build.props
@@ -1,5 +1,10 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
+
+  <!-- Import SDK.targets manually — Core plugins use ProjectReference not PackageReference,
+       so the .targets from the SDK NuGet package are not auto-imported -->
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Sdk\build\Spectara.Revela.Sdk.targets" />
+
   <!-- Insert "Core" segment: {Prefix}.Plugins.{ProjectName} → {Prefix}.Plugins.Core.{ProjectName} -->
   <PropertyGroup>
     <AssemblyName>$(RevelaNamespacePrefix).Plugins.Core.$(MSBuildProjectName)</AssemblyName>

--- a/src/Plugins/Core/Generate/Generate.csproj
+++ b/src/Plugins/Core/Generate/Generate.csproj
@@ -7,6 +7,10 @@
     <PackageReleaseNotes>https://github.com/spectara/revela/blob/main/CHANGELOG.md</PackageReleaseNotes>
     <PackageType>RevelaPlugin</PackageType>
 
+    <!-- Ensure all package dependencies are copied to output -->
+    <!-- Required because Core ProjectReference uses Private=false which breaks transitive copy -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+
     <!-- Plugin packaging handled by Spectara.Revela.Sdk.targets -->
   </PropertyGroup>
 

--- a/src/Plugins/Source/Calendar/SourceCalendarPlugin.cs
+++ b/src/Plugins/Source/Calendar/SourceCalendarPlugin.cs
@@ -19,7 +19,7 @@ namespace Spectara.Revela.Plugins.Source.Calendar;
 public sealed class SourceCalendarPlugin : IPlugin
 {
     /// <inheritdoc />
-    public PluginMetadata Metadata => new()
+    public PluginMetadata Metadata { get; } = new()
     {
         Id = "Spectara.Revela.Plugins.Source.Calendar",
         Name = "Source Calendar",

--- a/src/Plugins/Source/OneDrive/OneDrivePlugin.cs
+++ b/src/Plugins/Source/OneDrive/OneDrivePlugin.cs
@@ -17,7 +17,7 @@ namespace Spectara.Revela.Plugins.Source.OneDrive;
 public sealed class OneDrivePlugin : IPlugin
 {
     /// <inheritdoc />
-    public PluginMetadata Metadata => new()
+    public PluginMetadata Metadata { get; } = new()
     {
         Id = "Spectara.Revela.Plugins.Source.OneDrive",
         Name = "Source OneDrive",

--- a/src/Plugins/Statistics/StatisticsPlugin.cs
+++ b/src/Plugins/Statistics/StatisticsPlugin.cs
@@ -14,7 +14,7 @@ namespace Spectara.Revela.Plugins.Statistics;
 public sealed class StatisticsPlugin : IPlugin
 {
     /// <inheritdoc />
-    public PluginMetadata Metadata => new()
+    public PluginMetadata Metadata { get; } = new()
     {
         Id = "Spectara.Revela.Plugins.Statistics",
         Name = "Generate Statistics",

--- a/src/Sdk/Abstractions/IPlugin.cs
+++ b/src/Sdk/Abstractions/IPlugin.cs
@@ -54,9 +54,20 @@ public interface IPlugin
     /// Configure plugin-specific configuration sources (optional).
     /// </summary>
     /// <remarks>
-    /// Called BEFORE <see cref="ConfigureServices"/> to allow plugins to add custom config files.
-    /// Most plugins don't need this — plugin configs are stored in project.json,
-    /// and environment variables with SPECTARA__REVELA__ prefix are auto-loaded.
+    /// <para>
+    /// Called BEFORE <see cref="ConfigureServices"/>. Override only if your plugin needs
+    /// custom configuration sources beyond what the framework provides automatically:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>project.json section: <c>"Spectara.Revela.Plugins.YourPlugin": { ... }</c></item>
+    /// <item>Environment variables with <c>SPECTARA__REVELA__</c> prefix, where the remaining
+    /// key path matches the full section name using <c>__</c> as separator, e.g.:
+    /// <c>SPECTARA__REVELA__SPECTARA.REVELA.PLUGINS.YOURPLUGIN__SETTINGNAME=value</c></item>
+    /// </list>
+    /// <para>
+    /// Examples of when to override: loading config from a plugin-specific file,
+    /// connecting to an external configuration service, or adding computed defaults.
+    /// </para>
     /// </remarks>
     /// <param name="configuration">Configuration builder to add sources to.</param>
     void ConfigureConfiguration(IConfigurationBuilder configuration)

--- a/src/Sdk/Configuration/PluginOptions.cs
+++ b/src/Sdk/Configuration/PluginOptions.cs
@@ -42,7 +42,15 @@ public sealed class PluginOptions
     public bool EnableVerboseLogging { get; set; }
 
     /// <summary>
-    /// Plugin assembly patterns to exclude (e.g., "*.Tests.dll").
+    /// Plugin assembly filename patterns to exclude during discovery.
     /// </summary>
+    /// <remarks>
+    /// Supports leading wildcard patterns only:
+    /// <list type="bullet">
+    /// <item><c>*.Tests.dll</c> — excludes test assemblies</item>
+    /// <item><c>*.Mock.dll</c> — excludes mock assemblies</item>
+    /// </list>
+    /// Complex patterns like <c>*.Tests.*.dll</c> or trailing wildcards are not supported.
+    /// </remarks>
     public Collection<string> ExcludePatterns { get; } = [];
 }

--- a/src/Sdk/build/Spectara.Revela.Sdk.targets
+++ b/src/Sdk/build/Spectara.Revela.Sdk.targets
@@ -52,7 +52,7 @@
       <_PackageFiles Include="@(_RevelaAllDependencyDlls)"
                      Condition="!$([System.String]::new('%(Filename)').StartsWith('Spectara.Revela.'))
                                 And '%(Filename)' != 'System.CommandLine'
-                                And '%(Filename)' != 'Spectre.Console'
+                                And !$([System.String]::new('%(Filename)').StartsWith('Spectre.Console'))
                                 And (
                                   !$([System.String]::new('%(Filename)').StartsWith('Microsoft.Extensions.'))
                                   Or $([System.String]::new('%(Filename)').Contains('Http'))

--- a/tests/Core/PluginLoadContextTests.cs
+++ b/tests/Core/PluginLoadContextTests.cs
@@ -22,6 +22,7 @@ public sealed class PluginLoadContextTests
     [TestMethod]
     [DataRow("System.CommandLine")]
     [DataRow("Spectre.Console")]
+    [DataRow("Spectre.Console.Ansi")]
     public void IsSharedAssembly_ExplicitSharedThirdParty_ReturnsTrue(string assemblyName) =>
         Assert.IsTrue(PluginLoadContext.IsSharedAssembly(assemblyName));
 


### PR DESCRIPTION
## Summary

Closes #25

Fixes Core plugin loading in standalone builds and addresses all findings from a comprehensive plugin system code review.

## Root Cause

Core plugins (Generate, Theme, Projects) failed silently in standalone mode:

1. **Missing dependencies** — Plugin NuGet packages only contained the main DLL. Markdig, Scriban, NetVips were not included because `SDK.targets` was not imported via ProjectReference (auto-import only works for PackageReference). The `PluginLoadContext` couldn't resolve types → `ReflectionTypeLoadException` → silent failure.

2. **Spectre.Console.Ansi version mismatch** — SDK.targets and PluginLoadContext only filtered exact `Spectre.Console`, not sub-assemblies like `Spectre.Console.Ansi`. The plugin's bundled version conflicted with the host's version → `MissingMethodException`.

## Fixes

### Standalone Build (Critical)
- Import `SDK.targets` in `Core/Directory.Build.props` (enables NuGet packaging rules for Core plugins)
- Add `CopyLocalLockFileAssemblies=true` to `Generate.csproj` (ensures Markdig/Scriban/NetVips in build output)
- Fix `Spectre.Console.*` prefix matching in both `PluginLoadContext` and `SDK.targets`

### Plugin System Review Improvements
- **NupkgExtractor** — Use async `ZipFile.OpenReadAsync` / `ZipArchiveEntry.OpenAsync` (.NET 10 APIs)
- **PluginContext** — Specific exception types (`InvalidOperationException`, `ArgumentException`) with `Console.Error.WriteLine` for visibility during bootstrap
- **PluginLoader** — `Console.Error.WriteLine` for assembly load failures
- **PluginManager** — Handle `file://` URI scheme for local .nupkg paths
- **PluginLoadContext** — Improved shared assembly documentation with cross-references to SDK.targets
- **IPlugin** — Clarify `ConfigureConfiguration` docs for third-party developers
- **PluginOptions** — Document `ExcludePatterns` wildcard limitations
- **5 Plugins** — Fix Metadata from expression body (`=> new()`, allocates per access) to property initializer (`{ get; } = new()`, allocates once)

## Verification
- ✅ `dotnet build` — 0 errors, 0 warnings
- ✅ `dotnet test` — 386 passed, 0 failed
- ✅ `dotnet format --verify-no-changes` — clean
- ✅ Standalone build: wizard → install plugins → generate all → 23 images, 253 files, 3.33s