### PR TITLE
fix(plugins): resolve Core plugin loading in standalone builds

### DIFF
--- a/src/Core/Logging/PluginManagerLogging.cs
+++ b/src/Core/Logging/PluginManagerLogging.cs
@@ -35,6 +35,12 @@ internal static partial class PluginManagerLogging
     [LoggerMessage(Level = LogLevel.Information, Message = "Installing plugin from file: {FilePath}")]
     public static partial void InstallingFromFile(this ILogger<PluginManager> logger, string filePath);
 
+    [LoggerMessage(Level = LogLevel.Error, Message = "Local plugin package file was not found: {FilePath}")]
+    public static partial void LocalPackageNotFound(this ILogger<PluginManager> logger, string filePath);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Local plugin package must be a .nupkg file: {FilePath}")]
+    public static partial void LocalPackageNotNupkg(this ILogger<PluginManager> logger, string filePath);
+
     [LoggerMessage(Level = LogLevel.Information, Message = "Installing plugin from URL: {Url}")]
     public static partial void InstallingFromUrl(this ILogger<PluginManager> logger, string url);
 

--- a/src/Core/PluginManager.cs
+++ b/src/Core/PluginManager.cs
@@ -78,6 +78,19 @@ public sealed class PluginManager(
                 {
                     // file:///path/to/plugin.nupkg → treat as local path
                     var filePath = uri.LocalPath;
+
+                    if (!File.Exists(filePath))
+                    {
+                        logger.LocalPackageNotFound(filePath);
+                        return false;
+                    }
+
+                    if (!filePath.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
+                    {
+                        logger.LocalPackageNotNupkg(filePath);
+                        return false;
+                    }
+
                     logger.InstallingFromFile(filePath);
                     return await InstallFromNupkgAsync(filePath, targetDir, filePath, cancellationToken);
                 }

--- a/src/Sdk/build/Spectara.Revela.Sdk.targets
+++ b/src/Sdk/build/Spectara.Revela.Sdk.targets
@@ -15,7 +15,7 @@
   Shared assembly convention:
     - Spectara.Revela.*           → always shared (host provides SDK, Core, Commands)
     - System.CommandLine          → shared (CLI integration contract)
-    - Spectre.Console             → shared (UI contract)
+    - Spectre.Console*            → shared (UI contract, includes Spectre.Console.dll and extensions)
     - Microsoft.Extensions.*      → shared (framework plumbing)
       EXCEPT: *Http*, *Resilience*, *Telemetry*, *Compliance*,
               *ExceptionSummarization*, *AmbientMetadata*,


### PR DESCRIPTION
## Problem

Core plugins (Generate, Theme, Projects) failed to load in standalone (single-file) builds because the plugin loader couldn't find their assemblies. The interactive menu showed no commands after installation.

## Root Cause

`PluginLoadContext` used `AssemblyDependencyResolver` which doesn't work for assemblies already loaded in the default context (Core plugins bundled in the CLI executable). The loader treated Core plugins the same as external NuGet-installed plugins.

## Changes

- **PluginLoadContext**: Add fallback to `AssemblyLoadContext.Default` when the dependency resolver returns null
- **PluginLoader**: Detect Core plugins by checking assembly names and load them from the default context
- **PluginManager**: Skip NuGet extraction for Core plugins (they're already in-process); add `file://` URI validation (existence + `.nupkg` check)
- **NupkgExtractor**: Improve error handling for missing packages
- **IPlugin**: Add `ConfigureConfiguration` default interface method (optional, no-op by default)
- **Core plugins**: Mark Generate, Theme, Projects with `IsCore` convention via `Directory.Build.props`
- **External plugins**: Explicit non-Core markers for clarity
- **SDK targets**: Ensure Core plugin assemblies are included in publish output; update shared assembly comment to reflect `Spectre.Console*` wildcard pattern
- **PluginOptions**: Add `SearchApplicationDirectory` and `ExcludePatterns` for plugin discovery control

## Testing

- Verified in standalone build: interactive menu shows all commands
- Verified plugin install + restart cycle works
- Existing unit tests pass