### PR TITLE
chore(ci): deploy website only on release

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,6 +10,7 @@ This directory hosts all automation used to build, test, sign, and ship Revela. 
 | --- | --- | --- | --- |
 | CI | [`ci.yml`](ci.yml) | Push/PR to `main` or `develop`, manual dispatch | Multi-OS build (Windows/Linux/macOS), run all tests, pack CLI/plugins/themes for verification. |
 | Release | [`release.yml`](release.yml) | `v*` tag push or manual dispatch | Validate version, build binaries + NuGet packages, sign with cosign, create GitHub Release, publish to NuGet.org (with approval). |
+| Deploy Website | [`deploy-website.yml`](deploy-website.yml) | After successful Release run, or manual dispatch | Generate `samples/revela-website` against the latest release binary and push to `Spectara/Revela.Website`. Content-only fixes between releases use `workflow_dispatch`. |
 | Dependency Updates | [Dependabot](../dependabot.yml) | Weekly (Monday), automatic | Creates PRs for outdated NuGet packages and GitHub Actions. |
 
 > **Note**

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,18 +1,22 @@
 name: Deploy Website
 
+# Deployment policy: the live website always reflects the latest released
+# binary. Content iteration happens locally via
+# `cd samples/revela-website && dotnet run --project ../../src/Cli -- generate all`,
+# so there is no push-based auto-deploy. This keeps revela.website 1:1
+# consistent with what users can actually download.
+#
+# Triggers:
+#   - workflow_run: deploys after a successful Release workflow
+#   - workflow_dispatch: manual deploy for content-only fixes (typos,
+#     links, sponsor updates) without cutting a new release
 on:
   # Automatically deploy after a successful release
   workflow_run:
     workflows: ["Release"]
     types: [completed]
 
-  # Also deploy on website content changes (uses latest existing release)
-  push:
-    branches: [main]
-    paths:
-      - 'samples/revela-website/**'
-
-  # Manual trigger
+  # Manual trigger — used for content-only fixes between releases
   workflow_dispatch:
 
 # Only one website deployment at a time


### PR DESCRIPTION
Removes the push trigger on `samples/revela-website/**`. The website is now deployed exclusively after a successful Release workflow run; content-only fixes between releases use `workflow_dispatch`.

**Rationale:** the live site should always match the latest release users can actually download. Local preview via `dotnet run --project src/Cli -- generate all` is sufficient for content iteration, and avoids drift between deployed website content and the binary it describes.

Also adds the Deploy Website workflow to the workflows README table (was missing).